### PR TITLE
Add TURN configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 Please note: Replace <ENVIRONMENT> with either **production** or **staging** in the commands below
 
 ### Signal tower
-
+- to enable turn:
+  - set `palava_signaltower_turn_enabled` to `yes`
+  - set `palava_signaltower_turn_secret`
 - `ansible-playbook -i environments/<ENVIRONMENT>/inventory.yml playbooks/install_signaltower.yml`
 
 ### Palava Web
@@ -22,12 +24,14 @@ Please note: Replace <ENVIRONMENT> with either **production** or **staging** in 
 
 Requirements: jmespath (deployer host), unzip (target host)
 
+Adapt the variables in `environments/production/group_vars/all/main.yml` to your needs.
+
 ### Grafana
 
 - `ansible-galaxy install cloudalchemy.grafana`
-- `ansible-playbook -i environments/monitoring/inventory.yml playbooks/install_grafana.yml`
+- `ansible-playbook -i environments/production/inventory.yml playbooks/install_grafana.yml`
 
 ### Prometheus
 
 - `ansible-galaxy install cloudalchemy.prometheus`
-- `ansible-playbook -i environments/monitoring/inventory.yml playbooks/install_prometheus.yml`
+- `ansible-playbook -i environments/production/inventory.yml playbooks/install_prometheus.yml`

--- a/environments/production/group_vars/all/main.yml
+++ b/environments/production/group_vars/all/main.yml
@@ -4,6 +4,7 @@ palava_signaltower_install_dir: /srv/signaltower-production
 palava_signaltower_log_dir: /var/log/signaltower-production
 palava_environment: production
 # Used to configure the TURN server (turn role) to enable TURN in the signaltower role
+# palava_signaltower_turn_enabled: yes
 # palava_signaltower_turn_secret: SOME_SECRET_KEY
 
 palava_signaltower_autostart: yes

--- a/roles/palava-signaltower/defaults/main.yml
+++ b/roles/palava-signaltower/defaults/main.yml
@@ -5,6 +5,9 @@ palava_signaltower_log_dir: /var/log/signaltower
 palava_signaltower_port: 4233
 palava_signaltower_autostart: yes
 
+palava_signaltower_turn_enabled: no
+palava_signaltower_turn_secret: ''
+
 palava_signaltower_version: master
 
 palava_environment: production

--- a/roles/palava-signaltower/templates/signaltower.service.j2
+++ b/roles/palava-signaltower/templates/signaltower.service.j2
@@ -13,6 +13,9 @@ Restart=on-failure
 Type=forking
 RestartSec=5
 Environment=SIGNALTOWER_PORT={{ palava_signaltower_port }}
+{% if palava_signaltower_turn_secret %}
+Environment=SIGNALTOWER_TURN_SECRET={{ palava_signaltower_turn_secret }}
+{% endif %}
 Environment=LOG_FILE={{ palava_signaltower_log_dir }}/signaltower.log
 SyslogIdentifier=signaltower
 


### PR DESCRIPTION
TURN needs to be configured with a secret key that is the same that we use to configure the turn server.